### PR TITLE
Feature uid

### DIFF
--- a/POMPOM/POMPOM/Networking/ConnectionManager.swift
+++ b/POMPOM/POMPOM/Networking/ConnectionManager.swift
@@ -6,3 +6,18 @@
 //
 
 import Foundation
+import FirebaseFirestore
+
+struct ConnectionManager {
+    static private let usersRef = Firestore.firestore().collection("users")
+    
+    static func saveCode(code: String){
+        usersRef.addDocument(data: [
+            "code": code
+        ]) { err in
+            if let err = err {
+                dump("Error adding users 아래 문서: \(err)")
+            }
+        }
+    }
+}

--- a/POMPOM/POMPOM/Networking/ConnectionManager.swift
+++ b/POMPOM/POMPOM/Networking/ConnectionManager.swift
@@ -11,7 +11,18 @@ import FirebaseFirestore
 struct ConnectionManager {
     static private let usersRef = Firestore.firestore().collection("users")
     
-    static func saveCode(code: String){
+    static func isUniqueCode(code: String) async -> Bool {
+        var returnValue: Bool = false
+        
+        do {
+            let querySnapShot = try await usersRef.whereField("code", isEqualTo: code).getDocuments()
+            returnValue = querySnapShot.isEmpty ? true : false
+        } catch { }
+        
+        return returnValue
+    }
+    
+    static func saveCode(code: String) {
         usersRef.addDocument(data: [
             "code": code
         ]) { err in

--- a/POMPOM/POMPOM/Networking/ConnectionManager.swift
+++ b/POMPOM/POMPOM/Networking/ConnectionManager.swift
@@ -11,12 +11,12 @@ import FirebaseFirestore
 struct ConnectionManager {
     static private let usersRef = Firestore.firestore().collection("users")
     
-    static func isUniqueCode(code: String) async -> Bool {
+    static func isExistingCode(code: String) async -> Bool {
         var returnValue: Bool = false
         
         do {
             let querySnapShot = try await usersRef.whereField("code", isEqualTo: code).getDocuments()
-            returnValue = querySnapShot.isEmpty ? true : false
+            returnValue = querySnapShot.isEmpty ? false : true
         } catch { }
         
         return returnValue
@@ -24,11 +24,33 @@ struct ConnectionManager {
     
     static func saveCode(code: String) {
         usersRef.addDocument(data: [
-            "code": code
+            "code": code,
+            "partner_code": ""
         ]) { err in
             if let err = err {
                 dump("Error adding users 아래 문서: \(err)")
             }
         }
+    }
+    
+    static func updatePartnerCode(oneId: String, anotherCode: String) {
+        usersRef.document(oneId).updateData([
+            "partner_code": anotherCode
+        ]) { err in
+            if let err = err {
+                print("Error updating users 아래 문서: \(err)")
+            }
+        }
+    }
+    
+    static func getIdByCode(code: String) async -> String {
+        var returnValue: String = ""
+        
+        do {
+            let querySnapShot = try await usersRef.whereField("code", isEqualTo: code).getDocuments()
+            returnValue = querySnapShot.documents[0].documentID
+        } catch { }
+        
+        return returnValue
     }
 }

--- a/POMPOM/POMPOM/UI/CoupleView/ViewModel/CodeViewModel.swift
+++ b/POMPOM/POMPOM/UI/CoupleView/ViewModel/CodeViewModel.swift
@@ -6,3 +6,29 @@
 //
 
 import Foundation
+
+struct CodeViewModel {
+    private static let code: String = initializeCode()
+    
+    static func getCode() -> String { code }
+    
+    static func initializeCode() -> String {
+        // UserDefaults에 이미 code가 있을 때
+        if let defaultCode: String = UserDefaults.standard.string(forKey: "code") {
+            return defaultCode;
+        }
+        // UserDefaults에 code가 없을 때
+        else {
+            let code: String = generateCode(length: 10)
+            // code가 중복되지 않고 saveCode()가 100% 성공적으로 완료된다는 가정
+            ConnectionManager.saveCode(code: code)
+            return code;
+        }
+    }
+    
+    // 길이가 length고, 숫자와 영문 대문자로만 이뤄진 코드 생성 및 반환
+    static func generateCode(length: Int) -> String {
+        let elements = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        return String((0 ..< length).map { _ in elements.randomElement()! })
+    }
+}

--- a/POMPOM/POMPOM/UI/CoupleView/ViewModel/CodeViewModel.swift
+++ b/POMPOM/POMPOM/UI/CoupleView/ViewModel/CodeViewModel.swift
@@ -8,22 +8,30 @@
 import Foundation
 
 struct CodeViewModel {
-    private static let code: String = initializeCode()
+    private static let code: String = ""
     
-    static func getCode() -> String { code }
-    
-    static func initializeCode() -> String {
+    static func getCode() async -> String {
         // UserDefaults에 이미 code가 있을 때
         if let defaultCode: String = UserDefaults.standard.string(forKey: "code") {
             return defaultCode;
         }
         // UserDefaults에 code가 없을 때
         else {
-            let code: String = generateCode(length: 10)
-            // code가 중복되지 않고 saveCode()가 100% 성공적으로 완료된다는 가정
-            ConnectionManager.saveCode(code: code)
-            return code;
+            let newCode = await setNewCode()
+            ConnectionManager.saveCode(code: newCode)
+            UserDefaults.standard.set(newCode, forKey: "code")
+            return newCode;
         }
+    }
+    
+    static func setNewCode() async -> String {
+        var newCode: String = ""
+        
+        repeat {
+            newCode = generateCode(length: 10)
+        } while await ConnectionManager.isUniqueCode(code: newCode) == false
+        
+        return newCode
     }
     
     // 길이가 length고, 숫자와 영문 대문자로만 이뤄진 코드 생성 및 반환
@@ -31,4 +39,6 @@ struct CodeViewModel {
         let elements = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         return String((0 ..< length).map { _ in elements.randomElement()! })
     }
+    
+    
 }

--- a/POMPOM/POMPOM/UI/CoupleView/ViewModel/CodeViewModel.swift
+++ b/POMPOM/POMPOM/UI/CoupleView/ViewModel/CodeViewModel.swift
@@ -29,7 +29,7 @@ struct CodeViewModel {
         
         repeat {
             newCode = generateCode(length: 10)
-        } while await ConnectionManager.isUniqueCode(code: newCode) == false
+        } while await ConnectionManager.isExistingCode(code: newCode)
         
         return newCode
     }
@@ -40,5 +40,22 @@ struct CodeViewModel {
         return String((0 ..< length).map { _ in elements.randomElement()! })
     }
     
-    
+    static func connectWithPartner(partnerCode: String) async throws {
+        // partnerCode가 존재하는지부터 확인
+        guard await ConnectionManager.isExistingCode(code: partnerCode) else {
+            throw ConnectionManagerError.invalidPartnerCode
+        }
+        
+        let ownCode: String = await getCode()
+        
+        let ownId: String = await ConnectionManager.getIdByCode(code: ownCode)
+        let partnerId: String = await ConnectionManager.getIdByCode(code: partnerCode)
+        
+        ConnectionManager.updatePartnerCode(oneId: ownId, anotherCode: partnerCode)
+        ConnectionManager.updatePartnerCode(oneId: partnerId, anotherCode: ownCode)
+    }
+}
+
+enum ConnectionManagerError: Error {
+    case invalidPartnerCode // 일치하는 파트너 코드가 없는 경우
 }


### PR DESCRIPTION
## 작업내용
- `ConnectionManager.swift`: 커플 연결을 위해 Firestore와 통신하는 모듈
   - `isExistingCode(code: String) async -> Bool`: code가 DB에 존재하는지 확인
   - `saveCode(code: String)`: code를 DB에 저장
   - `updatePartnerCode(oneId: String, anotherCode: String)`: oneId를 ID로 가지는 문서에 anotherCode를 partner_id로 등록
   - `getIdByCode(code: String) async -> String`: code로 부터 문서 ID를 가져옴
- `CodeViewModel.swift`: CodeInputView & CodeOutputView에서 필요한 code에 대한 Model Struct
   - `getCode() async -> String`: 자신의 code를 가져옴
   - `setNewCode() async -> String`: UserDefaults에 저장된 자신의 코드가 없으면 새로운 코드를 발급
   - `connectWithPartner(partnerCode: String) async throws`: 입력 받은 partnerCode로 커플 연결

## 고민사항
- 네트워킹에서 비동기 로직를 `async` & `await` 문법으로 처리했습니다.
- `async` & `await`는 Swift 5.5, iOS 15 이상에서만 지원한다고 하는데 우리의 릴리즈 타겟이 어떻게 될지 논의를 해봐야겠습니다.
- 관련된 논의는 [여기](https://zeddios.tistory.com/1307)를 참고할 수 있습니다.

## 특이사항
- Manual 테스트를 진행했습니다.
- 테스트한 예외 케이스
   - 극히 낮은 확률이지만 발급한 코드가 DB에서 중복되는 경우
   - 사용자로 부터 입력 받은 파트너 코드가 DB에 없는 경우 `throw ConnectionMangerError.invalidPartnerCode`

## 사진
- 가시적인 View가 없습니다.
- CodeInputView & CodeOutputView를 위한 Model, Networking Module입니다.