### PR TITLE
Color preset save

### DIFF
--- a/POMPOM/POMPOM.xcodeproj/project.pbxproj
+++ b/POMPOM/POMPOM.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		AB132FE92854BE5C0023DBD0 /* Montserrat-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AB132FE72854BE5C0023DBD0 /* Montserrat-ExtraBold.ttf */; };
 		AB132FEA2854BE5C0023DBD0 /* Montserrat-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AB132FE82854BE5C0023DBD0 /* Montserrat-Bold.ttf */; };
 		AB132FED2854BF500023DBD0 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB132FEC2854BF500023DBD0 /* Constant.swift */; };
+		AB3ABBA8285AEB28002F9DD9 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3ABBA7285AEB28002F9DD9 /* CoreDataManager.swift */; };
+		AB3ABBAA285AECCA002F9DD9 /* BaseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3ABBA9285AECCA002F9DD9 /* BaseModel.swift */; };
 		ABC4C5192859A6FB00D064E4 /* SheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC4C5182859A6FB00D064E4 /* SheetView.swift */; };
 		ABFEE2122855A86D007817D3 /* CodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABFEE2112855A86D007817D3 /* CodeView.swift */; };
 		ABFEE2142855F2C1007817D3 /* CommentTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABFEE2132855F2C1007817D3 /* CommentTextField.swift */; };
@@ -62,6 +64,8 @@
 		AB132FE72854BE5C0023DBD0 /* Montserrat-ExtraBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Montserrat-ExtraBold.ttf"; sourceTree = "<group>"; };
 		AB132FE82854BE5C0023DBD0 /* Montserrat-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Montserrat-Bold.ttf"; sourceTree = "<group>"; };
 		AB132FEC2854BF500023DBD0 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
+		AB3ABBA7285AEB28002F9DD9 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
+		AB3ABBA9285AECCA002F9DD9 /* BaseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseModel.swift; sourceTree = "<group>"; };
 		ABC4C5182859A6FB00D064E4 /* SheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetView.swift; sourceTree = "<group>"; };
 		ABFEE2112855A86D007817D3 /* CodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeView.swift; sourceTree = "<group>"; };
 		ABFEE2132855F2C1007817D3 /* CommentTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentTextField.swift; sourceTree = "<group>"; };
@@ -148,6 +152,15 @@
 				AB132FEC2854BF500023DBD0 /* Constant.swift */,
 			);
 			path = Constants;
+			sourceTree = "<group>";
+		};
+		AB3ABBA6285AEB1C002F9DD9 /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				AB3ABBA7285AEB28002F9DD9 /* CoreDataManager.swift */,
+				AB3ABBA9285AECCA002F9DD9 /* BaseModel.swift */,
+			);
+			path = CoreData;
 			sourceTree = "<group>";
 		};
 		AEA32AA7285741B5006A31D4 /* ChatView */ = {
@@ -271,6 +284,7 @@
 		C0A779C52849E1C50086810C /* POMPOM */ = {
 			isa = PBXGroup;
 			children = (
+				AB3ABBA6285AEB1C002F9DD9 /* CoreData */,
 				C0ED415B2858697D007E5502 /* Models */,
 				C0ED4157285868D7007E5502 /* Util */,
 				C059279A2852FF8C0071751A /* Info.plist */,
@@ -484,6 +498,7 @@
 				ABFEE2122855A86D007817D3 /* CodeView.swift in Sources */,
 				C0754BA7284F1921005DBAFC /* DummyNetworkManager.swift in Sources */,
 				C06CE15B2851DCFE00BBDA68 /* ConnectionManager.swift in Sources */,
+				AB3ABBAA285AECCA002F9DD9 /* BaseModel.swift in Sources */,
 				AB132FED2854BF500023DBD0 /* Constant.swift in Sources */,
 				C0A779C72849E1C50086810C /* POMPOMApp.swift in Sources */,
 				C06CE1602851DD6700BBDA68 /* NotificationManager.swift in Sources */,
@@ -501,6 +516,7 @@
 				D430FCFE2859A76900F216CB /* ColorPickerView.swift in Sources */,
 				AEA32AAD285741DB006A31D4 /* MessageBubbleView.swift in Sources */,
 				C06CE1652851DDAB00BBDA68 /* LoginViewModel.swift in Sources */,
+				AB3ABBA8285AEB28002F9DD9 /* CoreDataManager.swift in Sources */,
 				C0F1DC0028575BA700F8EAA0 /* ClothPickerView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/POMPOM/POMPOM.xcodeproj/project.pbxproj
+++ b/POMPOM/POMPOM.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		AB132FED2854BF500023DBD0 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB132FEC2854BF500023DBD0 /* Constant.swift */; };
 		AB3ABBA8285AEB28002F9DD9 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3ABBA7285AEB28002F9DD9 /* CoreDataManager.swift */; };
 		AB3ABBAA285AECCA002F9DD9 /* BaseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3ABBA9285AECCA002F9DD9 /* BaseModel.swift */; };
+		AB3ABBAC285AF085002F9DD9 /* PresetColor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3ABBAB285AF085002F9DD9 /* PresetColor+Extensions.swift */; };
 		ABC4C5192859A6FB00D064E4 /* SheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC4C5182859A6FB00D064E4 /* SheetView.swift */; };
 		ABFEE2122855A86D007817D3 /* CodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABFEE2112855A86D007817D3 /* CodeView.swift */; };
 		ABFEE2142855F2C1007817D3 /* CommentTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABFEE2132855F2C1007817D3 /* CommentTextField.swift */; };
@@ -66,6 +67,7 @@
 		AB132FEC2854BF500023DBD0 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		AB3ABBA7285AEB28002F9DD9 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		AB3ABBA9285AECCA002F9DD9 /* BaseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseModel.swift; sourceTree = "<group>"; };
+		AB3ABBAB285AF085002F9DD9 /* PresetColor+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PresetColor+Extensions.swift"; sourceTree = "<group>"; };
 		ABC4C5182859A6FB00D064E4 /* SheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetView.swift; sourceTree = "<group>"; };
 		ABFEE2112855A86D007817D3 /* CodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeView.swift; sourceTree = "<group>"; };
 		ABFEE2132855F2C1007817D3 /* CommentTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentTextField.swift; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 			children = (
 				AB3ABBA7285AEB28002F9DD9 /* CoreDataManager.swift */,
 				AB3ABBA9285AECCA002F9DD9 /* BaseModel.swift */,
+				AB3ABBAB285AF085002F9DD9 /* PresetColor+Extensions.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -491,6 +494,7 @@
 				C0A779C72849E1C50086810C /* POMPOMApp.swift in Sources */,
 				C0F90CB32850729E00CC2C0E /* Secret.swift in Sources */,
 				C0182C3A28598411000F0A6A /* CategoryGrid.swift in Sources */,
+				AB3ABBAC285AF085002F9DD9 /* PresetColor+Extensions.swift in Sources */,
 				C06CE1502851DC5C00BBDA68 /* CodeOutputView.swift in Sources */,
 				C0F1DC0328575BCB00F8EAA0 /* PickerViewModel.swift in Sources */,
 				C06CE14E2851DC5100BBDA68 /* CodeInputView.swift in Sources */,

--- a/POMPOM/POMPOM/CoreData/BaseModel.swift
+++ b/POMPOM/POMPOM/CoreData/BaseModel.swift
@@ -1,0 +1,49 @@
+//
+//  BaseModel.swift
+//  POMPOM
+//
+//  Created by 김남건 on 2022/06/16.
+//
+
+import Foundation
+import CoreData
+
+protocol BaseModel: NSManagedObject {
+    func delete()
+    static func byId<T: NSManagedObject>(id: NSManagedObjectID) -> T?
+    static func all<T: NSManagedObject>() -> [T]
+}
+
+extension BaseModel {
+    static var viewContext: NSManagedObjectContext {
+        return CoreDataManager.shared.viewContext
+    }
+    
+    func save() {
+        CoreDataManager.shared.save()
+    }
+    
+    func delete() {
+        Self.viewContext.delete(self)
+        CoreDataManager.shared.save()
+    }
+    
+    static func byId<T> (id: NSManagedObjectID) -> T? where T: NSManagedObject {
+        do {
+            return try viewContext.existingObject(with: id) as? T
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+    
+    static func all<T>() -> [T] where T: NSManagedObject {
+        let fetchRequest: NSFetchRequest<T> = NSFetchRequest(entityName: String(describing: T.self))
+        
+        do {
+            return try viewContext.fetch(fetchRequest)
+        } catch {
+            return []
+        }
+    }
+}

--- a/POMPOM/POMPOM/CoreData/CoreDataManager.swift
+++ b/POMPOM/POMPOM/CoreData/CoreDataManager.swift
@@ -1,0 +1,35 @@
+//
+//  CoreDataManager.swift
+//  POMPOM
+//
+//  Created by 김남건 on 2022/06/16.
+//
+
+import Foundation
+import CoreData
+
+class CoreDataManager {
+    let persistentContainer: NSPersistentContainer
+    static let shared = CoreDataManager()
+    
+    private init() {
+        persistentContainer = NSPersistentContainer(name: "Model")
+        persistentContainer.loadPersistentStores { (description, error) in
+            if let error = error {
+                fatalError("Failed to initialize Core Data \(error)")
+            }
+        }
+    }
+    
+    var viewContext: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+    
+    func save() {
+        do {
+            try self.viewContext.save()
+        } catch {
+            self.viewContext.rollback()
+        }
+    }
+}

--- a/POMPOM/POMPOM/CoreData/PresetColor+Extensions.swift
+++ b/POMPOM/POMPOM/CoreData/PresetColor+Extensions.swift
@@ -20,7 +20,7 @@ extension PresetColor: BaseModel {
         }
     }
     
-    static func by(clothType: ClothCategory, hex: String) -> PresetColor? { // 같은 카테고리에 같은 색이 있는지 확인용
+    private static func by(clothType: ClothCategory, hex: String) -> PresetColor? { // 같은 카테고리에 같은 색이 있는지 확인용
         let request = PresetColor.fetchRequest()
         
         let hexPredicate = NSPredicate(format: "%K = %@", #keyPath(PresetColor.hex), hex)

--- a/POMPOM/POMPOM/CoreData/PresetColor+Extensions.swift
+++ b/POMPOM/POMPOM/CoreData/PresetColor+Extensions.swift
@@ -1,0 +1,47 @@
+//
+//  PresetColor+Extensions.swift
+//  POMPOM
+//
+//  Created by 김남건 on 2022/06/16.
+//
+
+import Foundation
+import CoreData
+
+extension PresetColor: BaseModel {
+    static func byClothType(_ clothType: ClothCategory) -> [PresetColor] {
+        let request = PresetColor.fetchRequest()
+        request.predicate = NSPredicate(format: "%K = %@", #keyPath(PresetColor.clothCategoryString), clothType.rawValue)
+        
+        do {
+            return try CoreDataManager.shared.viewContext.fetch(request)
+        } catch {
+            return []
+        }
+    }
+    
+    static func by(clothType: ClothCategory, hex: String) -> PresetColor? { // 같은 카테고리에 같은 색이 있는지 확인용
+        let request = PresetColor.fetchRequest()
+        
+        let hexPredicate = NSPredicate(format: "%K = %@", #keyPath(PresetColor.hex), hex)
+        let clothTypePredicate = NSPredicate(format: "%K = %@", #keyPath(PresetColor.clothCategoryString), clothType.rawValue)
+        
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [hexPredicate, clothTypePredicate])
+        
+        do {
+            return try CoreDataManager.shared.viewContext.fetch(request).first
+        } catch {
+            return nil
+        }
+    }
+    
+    static func savePresetColor(clothType: ClothCategory, hex: String) {
+        if by(clothType: clothType, hex: hex) != nil { return } // 중복 저장 방지
+        
+        let newPresetColor = PresetColor(context: CoreDataManager.shared.viewContext)
+        newPresetColor.hex = hex
+        newPresetColor.clothCategoryString = clothType.rawValue
+        
+        newPresetColor.save()
+    }
+}

--- a/POMPOM/POMPOM/Resources/Model.xcdatamodeld/POMPOM.xcdatamodel/contents
+++ b/POMPOM/POMPOM/Resources/Model.xcdatamodeld/POMPOM.xcdatamodel/contents
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
-    <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="class">
-        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="PresetColor" representedClassName="PresetColor" syncable="YES" codeGenerationType="class">
+        <attribute name="clothCategoryString" attributeType="String"/>
+        <attribute name="hex" attributeType="String"/>
     </entity>
     <elements>
-        <element name="Item" positionX="-63" positionY="-18" width="128" height="44"/>
+        <element name="PresetColor" positionX="-63" positionY="-18" width="128" height="59"/>
     </elements>
 </model>

--- a/POMPOM/POMPOM/Util/Extensions/Color.swift
+++ b/POMPOM/POMPOM/Util/Extensions/Color.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 extension Color {
     //Hex 코드를 이용한 Color 객체 생성
@@ -24,5 +25,15 @@ extension Color {
             green: CGFloat(g) / 0xff,
             blue: CGFloat(b) / 0xff
         )
+    }
+    
+    var hex: String {
+        let components = UIColor(self).cgColor.components!
+        
+        let r = Float(components[0])
+        let g = Float(components[1])
+        let b = Float(components[2])
+        
+        return String(format: "%02lX%02lX%02lX", lroundf(r * 255), lroundf(g * 255), lroundf(b * 255))
     }
 }


### PR DESCRIPTION
## 작업내용
* Preset Color를 Core Data에 저장하는 메서드 구현(`PresetColor.savePresetColor(clothType:hex)`)
* Preset Color를 불러오는 메서드 구현 (`PresetColor.byClothType(_:)`, `PresetColor.by(clothType:hex:)`)
* `Color`로부터 hex string 얻는 computed property 구현(`hex`)

## 특이사항
* `PresetColor.savePresetColor(clothType:hex)`에는 내부적으로 중복 저장 방지도 구현됨