### PR TITLE
Onboarding view 수정

### DIFF
--- a/POMPOM/POMPOM/UI/Onboarding/OnboardingPageView.swift
+++ b/POMPOM/POMPOM/UI/Onboarding/OnboardingPageView.swift
@@ -25,10 +25,13 @@ struct OnboardingPageView: View {
                 .multilineTextAlignment(.center)
                 .lineSpacing(6)
             Spacer()
-                .frame(height: Constant.screenHeight * (80 / 844))
+                .frame(height: Constant.screenHeight * (60 / 844))
             HStack {
                 Spacer()
                 Image(onboardingViewModel.onboardingImage)
+                    .resizable()
+                    .frame(width: onboardingViewModel.onboardingWidth, height: onboardingViewModel.onboardingHeight)
+                    
                 Spacer()
             }
             Spacer()

--- a/POMPOM/POMPOM/UI/Onboarding/OnboardingView.swift
+++ b/POMPOM/POMPOM/UI/Onboarding/OnboardingView.swift
@@ -17,6 +17,8 @@ struct OnboardingView: View {
             title: "내일 뭐 입고 올꺼야?",
             message: "커플 인생샷을 남기고 싶은데\n상대방이 무엇이 입고올지 고민인가요?",
             onboardingImage: "CuriousBear",
+            onboardingWidth: Constant.screenWidth * (520 / 390),
+            onboardingHeight: Constant.screenHeight * (255 / 844),
             isLast: false
         ),
         
@@ -24,6 +26,8 @@ struct OnboardingView: View {
             title: "코디 너로 결정!",
             message: "내 옷장에 색상을 넣고\n같이 컬러 조합을 맞춰봐요",
             onboardingImage: "ChooseClothes",
+            onboardingWidth: Constant.screenWidth * (360 / 390),
+            onboardingHeight: Constant.screenHeight * (455 / 844),
             isLast: false
         ),
         
@@ -31,6 +35,8 @@ struct OnboardingView: View {
             title: "함께 맞춰봐요",
             message: "상대방과 연결을 통해\n실시간으로 소통하며 확인해요",
             onboardingImage: "Connection",
+            onboardingWidth: Constant.screenWidth * (320 / 390),
+            onboardingHeight: Constant.screenHeight * (245 / 844),
             isLast: true
         )
     ]

--- a/POMPOM/POMPOM/UI/Onboarding/OnboardingViewModel.swift
+++ b/POMPOM/POMPOM/UI/Onboarding/OnboardingViewModel.swift
@@ -12,6 +12,8 @@ struct OnboardingViewModel: Identifiable {
     var title: String
     var message: String
     var onboardingImage: String
+    var onboardingWidth: CGFloat
+    var onboardingHeight:CGFloat
     var isLast: Bool
 }
 


### PR DESCRIPTION
## 작업내용
- SE와 mini에서 온보딩 글씨가 잘리는 것을 확인하여 이미지의 크기를 조정함.

## 고민사항
- SE 모델과 나머지 모델의 비율이 달라서 SE에서 이미지가 좀 압축되어 보임.

## 특이사항
- SE와 나머지 모델에서의 이미지 비율 차이가 있음.
- 글씨가 잘리지 않는 선에서 최대한 이미지의 비율을 조정함.

## 사진
[iPhon 13]
![스크린샷 2022-06-16 오후 11 42 25](https://user-images.githubusercontent.com/102962238/174097529-c79a24bd-a832-4fb6-a92e-c1c720711350.png)

![스크린샷 2022-06-16 오후 11 42 36](https://user-images.githubusercontent.com/102962238/174097567-53ad6f88-b995-4640-bad2-c8a443641483.png)

![스크린샷 2022-06-16 오후 11 42 45](https://user-images.githubusercontent.com/102962238/174097614-f44b9d58-6fc9-4271-b9fc-96dc9f768253.png)


[iPhon SE]
![스크린샷 2022-06-16 오후 11 43 02](https://user-images.githubusercontent.com/102962238/174097683-c4fd7f68-d838-4260-b1cd-beb9f9e8d0e8.png)

![스크린샷 2022-06-16 오후 11 43 19](https://user-images.githubusercontent.com/102962238/174097724-a978c320-2fcf-4eb5-91bb-22a9cacdc5c0.png)

![스크린샷 2022-06-16 오후 11 43 33](https://user-images.githubusercontent.com/102962238/174097764-4bdcb3a6-7d54-4875-86a4-42797781c79a.png)