### PR TITLE
[FIX] 옷 초기화 버튼 누른 후 데이터 일관성 문제 해결

### DIFF
--- a/POMPOM/POMPOM/Models/Cloth.swift
+++ b/POMPOM/POMPOM/Models/Cloth.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct Cloth: Identifiable {
+    
     var id: String
     var hex: String
     var category: ClothCategory

--- a/POMPOM/POMPOM/Networking/ConnectionManager.swift
+++ b/POMPOM/POMPOM/Networking/ConnectionManager.swift
@@ -29,8 +29,8 @@ struct ConnectionManager {
         ]) { err in
             if let err = err {
                 dump("Error adding users 아래 문서: \(err)")
+                print("DEBUG: ConnectionManager - \(err.localizedDescription)")
             }
-            print(err)
         }
     }
     
@@ -39,7 +39,7 @@ struct ConnectionManager {
             "partner_code": anotherCode
         ]) { err in
             if let err = err {
-                print("Error updating users 아래 문서: \(err)")
+                print("DEBUG: ConnectionManager - \(err)")
             }
         }
     }
@@ -49,7 +49,7 @@ struct ConnectionManager {
             "partner_code" : ""
         ]) { err in
             if let err = err {
-                print("DEBUG: 파트너 코드 삭제 실패")
+                print("DEBUG: ConnectionManager - \(err.localizedDescription)")
             }
         }
     }

--- a/POMPOM/POMPOM/UI/ChatView/TextFieldView.swift
+++ b/POMPOM/POMPOM/UI/ChatView/TextFieldView.swift
@@ -34,8 +34,8 @@ struct TextFieldView: View {
     }
     
     func sendMessage() async {
-        var myCode = await CodeManager().getCode()
-        var partnerCode = CodeManager().getPartnerCode()
+        let myCode =  CodeManager().getCode()
+        let partnerCode = CodeManager().getPartnerCode()
         
         reference.addDocument(data: [
             "id": Int(Date().timeIntervalSince1970*1000),

--- a/POMPOM/POMPOM/UI/CoupleView/CodeInputView.swift
+++ b/POMPOM/POMPOM/UI/CoupleView/CodeInputView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CodeInputView: View {
     @Binding var textInput: String
     var delegate: NetworkDelegate?
-    private let codeViewModel: CodeManager = CodeManager()
+    private let codeManager: CodeManager = CodeManager()
     let afterAction: () -> ()
     
     var body: some View {
@@ -21,7 +21,7 @@ struct CodeInputView: View {
         }, buttonTitle: "확인", buttonAction: {
             Task {
                 do {
-                    try await codeViewModel.connectWithPartner(partnerCode: textInput)
+                    try await codeManager.connectWithPartner(partnerCode: textInput)
                 } catch ConnectionManagerResultType.success {
                     delegate?.didConnectedPartner()
                 } catch ConnectionManagerResultType.callMySelf {

--- a/POMPOM/POMPOM/UI/CoupleView/CoupleView.swift
+++ b/POMPOM/POMPOM/UI/CoupleView/CoupleView.swift
@@ -195,6 +195,11 @@ struct CoupleView: View {
                         Button("완료") {
                             myClothViewModel.uploadItem()
                             sheetMode = .none
+                            
+                            Task {
+                                await myClothViewModel.requestClothes()
+                                await partnerClothViewModel.requestPartnerClothes()
+                            }
                         }
                     }
                 }
@@ -260,7 +265,7 @@ struct ClothView: View {
     var category: ClothCategory
     
     var body: some View {
-        if vm.selectedItems[category] != nil {
+        if vm.isValidItem(with: category) {
             ZStack {
                 Image(vm.fetchImageString(with: category) + "B")
                     .resizable()
@@ -281,7 +286,7 @@ struct AccesoriesView: View {
     @ObservedObject var vm: ClothViewModel
    
     var body: some View {
-        if vm.selectedItems[.accessories] != nil {
+        if vm.isValidItem(with: .accessories) {
             ZStack {
                 Image(vm.fetchImageString(with: .accessories))
                     .resizable()

--- a/POMPOM/POMPOM/UI/CoupleView/ViewModel/ClothViewModel.swift
+++ b/POMPOM/POMPOM/UI/CoupleView/ViewModel/ClothViewModel.swift
@@ -39,7 +39,19 @@ class ClothViewModel: ObservableObject {
     }
     
     func clearSelectedItem() {
-        selectedItems.removeAll()
+//        selectedItems.removeAll()
+        for key in selectedItems.keys {
+            selectedItems[key] = Cloth(id: "", hex: "", category: key)
+        }
+        print(selectedItems)
+    }
+    
+    func isValidItem(with category: ClothCategory) -> Bool {
+        guard let selectedItem = selectedItems[category] else {
+            return false
+        }
+        
+        return selectedItem.id != ""
     }
     
     func fetchImageString(with category: ClothCategory) -> String {

--- a/POMPOM/POMPOM/UI/SettingsView/SettingsView.swift
+++ b/POMPOM/POMPOM/UI/SettingsView/SettingsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(\.presentationMode) var presentationMode
+    private let codeManager: CodeManager = CodeManager()
     @State private var actionSheetPresented = false
     @State private var codeInput = ""
     @Binding var showAlert: Bool


### PR DESCRIPTION
## 작업내용
- 옷 초기화 버튼 누른 후 데이터 일관성 문제 해결

## 고민사항
- 내용을 적어주세요.

## 특이사항
- 초기화 버튼 누를 시 딕셔너리에 키값을 삭제하기 보다, 비어있는 Cloth 아이템을 추가하도록 하였습니다.

## 사진