### PR TITLE
[REFACTOR] 네트워킹 로직 리팩터링

### DIFF
--- a/POMPOM/POMPOM.xcodeproj/project.pbxproj
+++ b/POMPOM/POMPOM.xcodeproj/project.pbxproj
@@ -35,8 +35,8 @@
 		C06CE14E2851DC5100BBDA68 /* CodeInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE14D2851DC5100BBDA68 /* CodeInputView.swift */; };
 		C06CE1502851DC5C00BBDA68 /* CodeOutputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE14F2851DC5C00BBDA68 /* CodeOutputView.swift */; };
 		C06CE1532851DC7F00BBDA68 /* ClothesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE1522851DC7F00BBDA68 /* ClothesViewModel.swift */; };
-		C06CE1592851DCD600BBDA68 /* CodeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE1582851DCD600BBDA68 /* CodeManager.swift */; };
-		C06CE15B2851DCFE00BBDA68 /* ConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE15A2851DCFE00BBDA68 /* ConnectionManager.swift */; };
+		C06CE1592851DCD600BBDA68 /* ConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE1582851DCD600BBDA68 /* ConnectionManager.swift */; };
+		C06CE15B2851DCFE00BBDA68 /* CodeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE15A2851DCFE00BBDA68 /* CodeManager.swift */; };
 		C06CE15E2851DD4800BBDA68 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE15D2851DD4800BBDA68 /* OnboardingView.swift */; };
 		C06CE1602851DD6700BBDA68 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE15F2851DD6700BBDA68 /* NotificationManager.swift */; };
 		C06CE1632851DD8500BBDA68 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE1622851DD8500BBDA68 /* LoginView.swift */; };
@@ -95,8 +95,8 @@
 		C06CE14D2851DC5100BBDA68 /* CodeInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeInputView.swift; sourceTree = "<group>"; };
 		C06CE14F2851DC5C00BBDA68 /* CodeOutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeOutputView.swift; sourceTree = "<group>"; };
 		C06CE1522851DC7F00BBDA68 /* ClothesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothesViewModel.swift; sourceTree = "<group>"; };
-		C06CE1582851DCD600BBDA68 /* CodeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeManager.swift; sourceTree = "<group>"; };
-		C06CE15A2851DCFE00BBDA68 /* ConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionManager.swift; sourceTree = "<group>"; };
+		C06CE1582851DCD600BBDA68 /* ConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionManager.swift; sourceTree = "<group>"; };
+		C06CE15A2851DCFE00BBDA68 /* CodeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeManager.swift; sourceTree = "<group>"; };
 		C06CE15D2851DD4800BBDA68 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		C06CE15F2851DD6700BBDA68 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		C06CE1622851DD8500BBDA68 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
@@ -234,8 +234,8 @@
 		C04795C7284F15D20040646A /* Networking */ = {
 			isa = PBXGroup;
 			children = (
-				C06CE15A2851DCFE00BBDA68 /* ConnectionManager.swift */,
-				C06CE1582851DCD600BBDA68 /* CodeManager.swift */,
+				C06CE15A2851DCFE00BBDA68 /* CodeManager.swift */,
+				C06CE1582851DCD600BBDA68 /* ConnectionManager.swift */,
 				C06CE15F2851DD6700BBDA68 /* NotificationManager.swift */,
 				2521EC75285A0D2400B02E1A /* ClothesManager.swift */,
 			);
@@ -509,7 +509,7 @@
 				C06CE14B2851DC0900BBDA68 /* CoupleView.swift in Sources */,
 				C0ED415D28586989007E5502 /* Cloth.swift in Sources */,
 				ABC4C5192859A6FB00D064E4 /* SheetView.swift in Sources */,
-				C06CE1592851DCD600BBDA68 /* CodeManager.swift in Sources */,
+				C06CE1592851DCD600BBDA68 /* ConnectionManager.swift in Sources */,
 				C0A779C72849E1C50086810C /* POMPOMApp.swift in Sources */,
 				AE850A07285B238D00D11812 /* Message.swift in Sources */,
 				C0C7EE9A285B42A2003DA1A9 /* CustomAlert.swift in Sources */,
@@ -523,7 +523,7 @@
 				C0182C3828598407000F0A6A /* ColorGrid.swift in Sources */,
 				ABFEE2122855A86D007817D3 /* CodeView.swift in Sources */,
 				8A0732CE285B057B00E72AD9 /* SettingsView.swift in Sources */,
-				C06CE15B2851DCFE00BBDA68 /* ConnectionManager.swift in Sources */,
+				C06CE15B2851DCFE00BBDA68 /* CodeManager.swift in Sources */,
 				AB3ABBAA285AECCA002F9DD9 /* BaseModel.swift in Sources */,
 				AB132FED2854BF500023DBD0 /* Constant.swift in Sources */,
 				C0A779C72849E1C50086810C /* POMPOMApp.swift in Sources */,

--- a/POMPOM/POMPOM.xcodeproj/project.pbxproj
+++ b/POMPOM/POMPOM.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		C06CE14B2851DC0900BBDA68 /* CoupleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE14A2851DC0900BBDA68 /* CoupleView.swift */; };
 		C06CE14E2851DC5100BBDA68 /* CodeInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE14D2851DC5100BBDA68 /* CodeInputView.swift */; };
 		C06CE1502851DC5C00BBDA68 /* CodeOutputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE14F2851DC5C00BBDA68 /* CodeOutputView.swift */; };
-		C06CE1532851DC7F00BBDA68 /* ClothViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE1522851DC7F00BBDA68 /* ClothViewModel.swift */; };
+		C06CE1532851DC7F00BBDA68 /* ClothesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE1522851DC7F00BBDA68 /* ClothesViewModel.swift */; };
 		C06CE1592851DCD600BBDA68 /* CodeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE1582851DCD600BBDA68 /* CodeManager.swift */; };
 		C06CE15B2851DCFE00BBDA68 /* ConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE15A2851DCFE00BBDA68 /* ConnectionManager.swift */; };
 		C06CE15E2851DD4800BBDA68 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06CE15D2851DD4800BBDA68 /* OnboardingView.swift */; };
@@ -94,7 +94,7 @@
 		C06CE14A2851DC0900BBDA68 /* CoupleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoupleView.swift; sourceTree = "<group>"; };
 		C06CE14D2851DC5100BBDA68 /* CodeInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeInputView.swift; sourceTree = "<group>"; };
 		C06CE14F2851DC5C00BBDA68 /* CodeOutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeOutputView.swift; sourceTree = "<group>"; };
-		C06CE1522851DC7F00BBDA68 /* ClothViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothViewModel.swift; sourceTree = "<group>"; };
+		C06CE1522851DC7F00BBDA68 /* ClothesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClothesViewModel.swift; sourceTree = "<group>"; };
 		C06CE1582851DCD600BBDA68 /* CodeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeManager.swift; sourceTree = "<group>"; };
 		C06CE15A2851DCFE00BBDA68 /* ConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionManager.swift; sourceTree = "<group>"; };
 		C06CE15D2851DD4800BBDA68 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -259,7 +259,7 @@
 		C06CE1512851DC6300BBDA68 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				C06CE1522851DC7F00BBDA68 /* ClothViewModel.swift */,
+				C06CE1522851DC7F00BBDA68 /* ClothesViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -502,7 +502,7 @@
 			files = (
 				C0182C3C2859841A000F0A6A /* ClothGrid.swift in Sources */,
 				C0A779C92849E1C50086810C /* ContentView.swift in Sources */,
-				C06CE1532851DC7F00BBDA68 /* ClothViewModel.swift in Sources */,
+				C06CE1532851DC7F00BBDA68 /* ClothesViewModel.swift in Sources */,
 				C0F90CB32850729E00CC2C0E /* Secret.swift in Sources */,
 				C06CE15E2851DD4800BBDA68 /* OnboardingView.swift in Sources */,
 				AEA32AAB285741CF006A31D4 /* MessageListView.swift in Sources */,

--- a/POMPOM/POMPOM/Models/Message.swift
+++ b/POMPOM/POMPOM/Models/Message.swift
@@ -17,7 +17,7 @@ class messageData: ObservableObject{
     }
     
     func readMessages() {
-        let myCode = CodeManager().getCode()
+        let myCode = ConnectionManager().getCode()
         reference.collection("message").order(by: "timestamp", descending: false).addSnapshotListener {
             (snap, err) in
             

--- a/POMPOM/POMPOM/Networking/ClothesManager.swift
+++ b/POMPOM/POMPOM/Networking/ClothesManager.swift
@@ -8,14 +8,23 @@
 import Foundation
 import FirebaseFirestore
 
+
+
 struct ClothesManager {
     let clothesRef = Firestore.firestore().collection("clothes")
     
-    func saveClothes(userCode: String, clothes: [ClothCategory: Cloth]) {
-        clothesRef.document(userCode).setData(parseClothes(clothes: clothes))
+    func saveClothes(userCode: String, clothes: [ClothCategory: Cloth], completion: @escaping (Result<Void, Error>) -> Void) {
+      
+        clothesRef.document().setData(parseClothes(clothes: clothes)) { error in
+            if let error = error {
+                completion(.failure(error))
+            } else {
+                completion(.success(()))
+            }
+        }
     }
     
-    func parseClothes(clothes: [ClothCategory: Cloth]) -> [String: Any] {
+    private func parseClothes(clothes: [ClothCategory: Cloth]) -> [String: Any] {
         var returnValue: [String: Any] = [:]
         
         for clothCategory in ClothCategory.allCases {

--- a/POMPOM/POMPOM/Networking/ClothesManager.swift
+++ b/POMPOM/POMPOM/Networking/ClothesManager.swift
@@ -13,9 +13,9 @@ import FirebaseFirestore
 struct ClothesManager {
     let clothesRef = Firestore.firestore().collection("clothes")
     
-    func saveClothes(userCode: String, clothes: [ClothCategory: Cloth], completion: @escaping (Result<Void, Error>) -> Void) {
-      
-        clothesRef.document().setData(parseClothes(clothes: clothes)) { error in
+    //옷을 업로드 하는 메서드
+    func setClothes(userCode: String, clothes: [ClothCategory: Cloth], completion: @escaping (Result<Void, Error>) -> Void) {
+        clothesRef.document(userCode).setData(parse(clothes: clothes)) { error in
             if let error = error {
                 completion(.failure(error))
             } else {
@@ -24,7 +24,62 @@ struct ClothesManager {
         }
     }
     
-    private func parseClothes(clothes: [ClothCategory: Cloth]) -> [String: Any] {
+    
+    //한번만 옷을 불러오는 메서드
+    func fetchClohtes(userCode: String, completion: @escaping (Result<[ClothCategory: Cloth], Error>) -> Void) {
+        var returnValue: [ClothCategory: Cloth] = [:]
+        
+        clothesRef.document(userCode).getDocument { snapShot, error in
+            guard let data = snapShot?.data() else {
+                completion(.success(returnValue))
+                return
+            }
+            
+            switch error {
+            case .none:
+                for clothCategory in ClothCategory.allCases {
+                    if let cloth: [String] = data[clothCategory.rawValue] as! [String]? {
+                        if !(cloth[0].isEmpty && cloth[1].isEmpty) {
+                            returnValue[clothCategory] = Cloth(id: cloth[0], hex: cloth[1], category: clothCategory)
+                        }
+                    }
+                }
+                completion(.success(returnValue))
+            case .some(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    //옷이 변경됨을 관찰하는 리스너를 붙이는 메서드
+    func addClothesListner(userCode: String, completion: @escaping (Result<[ClothCategory : Cloth], Error>) -> Void) {
+        var returnValue: [ClothCategory: Cloth] = [:]
+        
+        clothesRef.document(userCode).addSnapshotListener { snapShot, error in
+            guard let data = snapShot?.data() else {
+                completion(.success(returnValue))
+                return
+            }
+
+            switch error {
+            case .none:
+                for clothCategory in ClothCategory.allCases {
+                    if let cloth: [String] = data[clothCategory.rawValue] as! [String]? {
+                        if !(cloth[0].isEmpty && cloth[1].isEmpty) {
+                            returnValue[clothCategory] = Cloth(id: cloth[0], hex: cloth[1], category: clothCategory)
+                        }
+                    }
+                }
+                completion(.success(returnValue))
+            case .some(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    //MARK: - Private Helpers
+    
+    private func parse(clothes: [ClothCategory: Cloth]) -> [String: Any] {
         var returnValue: [String: Any] = [:]
         
         for clothCategory in ClothCategory.allCases {
@@ -36,32 +91,5 @@ struct ClothesManager {
         }
         
         return returnValue
-    }
-    
-    func loadClothes(userCode: String, competion: @escaping ([ClothCategory : Cloth]) -> Void) {
-        var returnValue: [ClothCategory: Cloth] = [:]
-        
-        clothesRef.document(userCode).addSnapshotListener { snapShot, error in
-            guard let data = snapShot?.data() else { competion(returnValue)
-                return
-            }
-            
-            print("Here is listener")
-
-            switch error {
-            case .none:
-                for clothCategory in ClothCategory.allCases {
-                    if let cloth: [String] = data[clothCategory.rawValue] as! [String]? {
-                        if !(cloth[0].isEmpty && cloth[1].isEmpty) {
-                            returnValue[clothCategory] = Cloth(id: cloth[0], hex: cloth[1], category: clothCategory)
-                        }
-                    }
-                }
-                competion(returnValue)
-            case .some(let error):
-                print("DEBUG: 옷 불러오기 에러 - \(error)")
-            }
-            
-        }
     }
 }

--- a/POMPOM/POMPOM/Networking/CodeManager.swift
+++ b/POMPOM/POMPOM/Networking/CodeManager.swift
@@ -13,13 +13,11 @@ struct ConnectionManager {
     
     @discardableResult
     func getCode() -> String {
-        // UserDefaults에 이미 code가 있을 때
         if let defaultCode: String = UserDefaults.standard.string(forKey: "code") {
+            // UserDefaults에 이미 code가 있을 때
             return defaultCode
-        }
-        // UserDefaults에 code가 없을 때
-        else {
-//            let newCode = await setNewCode()
+        } else {
+            // UserDefaults에 code가 없을 때
             let newCode = generateCode(length: 10)
             DispatchQueue.global().async {
                 codeManager.saveCode(code: newCode)

--- a/POMPOM/POMPOM/Networking/CodeManager.swift
+++ b/POMPOM/POMPOM/Networking/CodeManager.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-struct CodeManager {
+struct ConnectionManager {
     private let code: String = ""
-    private let connectionManager: ConnectionManager = ConnectionManager()
+    private let codeManager: CodeManager = CodeManager()
     
     @discardableResult
     func getCode() -> String {
@@ -22,7 +22,7 @@ struct CodeManager {
 //            let newCode = await setNewCode()
             let newCode = generateCode(length: 10)
             DispatchQueue.global().async {
-                connectionManager.saveCode(code: newCode)
+                codeManager.saveCode(code: newCode)
             }
             UserDefaults.standard.set(newCode, forKey: "code")
             print("DEUBG: 코드 생성 완료 - \(newCode)")
@@ -35,7 +35,7 @@ struct CodeManager {
         
         repeat {
             newCode = generateCode(length: 10)
-        } while await connectionManager.isExistingCode(code: newCode)
+        } while await codeManager.isExistingCode(code: newCode)
         
         return newCode
     }
@@ -53,17 +53,17 @@ struct CodeManager {
         }
         
         // partnerCode가 존재하는지부터 확인
-        guard await connectionManager.isExistingCode(code: partnerCode) else {
+        guard await codeManager.isExistingCode(code: partnerCode) else {
             throw ConnectionManagerResultType.invalidPartnerCode
         }
         
         let ownCode: String = getCode()
         
-        let ownId: String = await connectionManager.getIdByCode(code: ownCode)
-        let partnerId: String = await connectionManager.getIdByCode(code: partnerCode)
+        let ownId: String = await codeManager.getIdByCode(code: ownCode)
+        let partnerId: String = await codeManager.getIdByCode(code: partnerCode)
         
-        connectionManager.updatePartnerCode(oneId: ownId, anotherCode: partnerCode)
-        connectionManager.updatePartnerCode(oneId: partnerId, anotherCode: ownCode)
+        codeManager.updatePartnerCode(oneId: ownId, anotherCode: partnerCode)
+        codeManager.updatePartnerCode(oneId: partnerId, anotherCode: ownCode)
         UserDefaults.standard.set(partnerCode, forKey: "partner_code")
         throw ConnectionManagerResultType.success
     }
@@ -82,7 +82,7 @@ struct CodeManager {
     func getPartnerCodeFromServer(completion: @escaping (String) -> Void) async {
         
         
-        connectionManager.usersRef.document(await connectionManager.getIdByCode(code: getCode()))
+        codeManager.usersRef.document(await codeManager.getIdByCode(code: getCode()))
             .addSnapshotListener { snapShot, err in
                 if let err = err {
                     dump("\(err)")
@@ -102,8 +102,8 @@ struct CodeManager {
     
     func deletePartnerCode(completion: @escaping (String) -> Void) {
         Task {
-            await connectionManager.updatePartnerCodeBy(ownCode: getPartnerCode())
-            await connectionManager.updatePartnerCodeBy(ownCode: getCode())
+            await codeManager.updatePartnerCodeBy(ownCode: getPartnerCode())
+            await codeManager.updatePartnerCodeBy(ownCode: getCode())
         }
         
         if let _ = UserDefaults.standard.string(forKey: "partner_code") {

--- a/POMPOM/POMPOM/Networking/CodeManager.swift
+++ b/POMPOM/POMPOM/Networking/CodeManager.swift
@@ -1,121 +1,76 @@
 //
-//  CodeViewModel.swift
+//  ConnectionManager.swift
 //  POMPOM
 //
 //  Created by GOngTAE on 2022/06/09.
 //
 
 import Foundation
+import FirebaseFirestore
 
-struct ConnectionManager {
-    private let code: String = ""
-    private let codeManager: CodeManager = CodeManager()
+struct CodeManager {
+    let usersRef = Firestore.firestore().collection("users")
     
-    @discardableResult
-    func getCode() -> String {
-        if let defaultCode: String = UserDefaults.standard.string(forKey: "code") {
-            // UserDefaults에 이미 code가 있을 때
-            return defaultCode
-        } else {
-            // UserDefaults에 code가 없을 때
-            let newCode = generateCode(length: 10)
-            DispatchQueue.global().async {
-                codeManager.saveCode(code: newCode)
+    func isExistingCode(code: String) async -> Bool {
+        var returnValue: Bool = false
+        
+        do {
+            let querySnapShot = try await usersRef.whereField("code", isEqualTo: code).getDocuments()
+            returnValue = querySnapShot.isEmpty ? false : true
+        } catch { }
+        
+        return returnValue
+    }
+    
+    func saveCode(code: String) {
+        usersRef.addDocument(data: [
+            "code": code,
+            "partner_code": ""
+        ]) { err in
+            if let err = err {
+                dump("Error adding users 아래 문서: \(err)")
+                print("DEBUG: ConnectionManager - \(err.localizedDescription)")
             }
-            UserDefaults.standard.set(newCode, forKey: "code")
-            print("DEUBG: 코드 생성 완료 - \(newCode)")
-            return newCode
         }
     }
     
-    func setNewCode() async -> String {
-        var newCode: String = ""
-        
-        repeat {
-            newCode = generateCode(length: 10)
-        } while await codeManager.isExistingCode(code: newCode)
-        
-        return newCode
-    }
-    
-    // 길이가 length고, 숫자와 영문 대문자로만 이뤄진 코드 생성 및 반환
-    private func generateCode(length: Int) -> String {
-        let elements = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        return String((0 ..< length).map { _ in elements.randomElement()! })
-    }
-    
-    func connectWithPartner(partnerCode: String) async throws {
-        // partnerCode를 본인의 코드로 입력했는지 확인
-        guard partnerCode != getCode() else {
-            throw ConnectionManagerResultType.callMySelf
-        }
-        
-        // partnerCode가 존재하는지부터 확인
-        guard await codeManager.isExistingCode(code: partnerCode) else {
-            throw ConnectionManagerResultType.invalidPartnerCode
-        }
-        
-        let ownCode: String = getCode()
-        
-        let ownId: String = await codeManager.getIdByCode(code: ownCode)
-        let partnerId: String = await codeManager.getIdByCode(code: partnerCode)
-        
-        codeManager.updatePartnerCode(oneId: ownId, anotherCode: partnerCode)
-        codeManager.updatePartnerCode(oneId: partnerId, anotherCode: ownCode)
-        UserDefaults.standard.set(partnerCode, forKey: "partner_code")
-        throw ConnectionManagerResultType.success
-    }
-    
-    func getPartnerCode() -> String {
-        // UserDefaults에 partner_code가 있을 때
-        if let partnerCode: String = UserDefaults.standard.string(forKey: "partner_code") {
-            return partnerCode
-        }
-        // UserDefaults에 partner_code가 없을 때
-        else {
-            return ""
-        }
-    }
-    
-    func getPartnerCodeFromServer(completion: @escaping (String) -> Void) async {
-        
-        
-        codeManager.usersRef.document(await codeManager.getIdByCode(code: getCode()))
-            .addSnapshotListener { snapShot, err in
-                if let err = err {
-                    dump("\(err)")
-                } else {
-                    guard let data = snapShot?.data()?["partner_code"] as? String else { return }
-                    var temp = ""
-                    print(data)
-                    if data != " " {
-                        temp = data
-                    }
-                    UserDefaults.standard.set(temp, forKey: "partner_code")
-                    print(temp + "wow")
-                    completion(temp)
-                }
+    func updatePartnerCode(oneId: String, anotherCode: String) {
+        usersRef.document(oneId).updateData([
+            "partner_code": anotherCode
+        ]) { err in
+            if let err = err {
+                print("DEBUG: ConnectionManager - \(err)")
             }
+        }
     }
     
-    func deletePartnerCode(completion: @escaping (String) -> Void) {
-        Task {
-            await codeManager.updatePartnerCodeBy(ownCode: getPartnerCode())
-            await codeManager.updatePartnerCodeBy(ownCode: getCode())
+    func deletePartnerCode(oneId: String) {
+        usersRef.document(oneId).updateData([
+            "partner_code" : ""
+        ]) { err in
+            if let err = err {
+                print("DEBUG: ConnectionManager - \(err.localizedDescription)")
+            }
         }
+    }
+    
+    func getIdByCode(code: String) async -> String {
+        var returnValue: String = ""
         
-        if let _ = UserDefaults.standard.string(forKey: "partner_code") {
-            UserDefaults.standard.removeObject(forKey: "partner_code")
-            
+        do {
+            let querySnapShot = try await usersRef.whereField("code", isEqualTo: code).getDocuments()
+            returnValue = querySnapShot.documents[0].documentID
+        } catch { }
+        
+        return returnValue
+    }
+    
+    func updatePartnerCodeBy(ownCode: String) async {
+        do {
+            try await usersRef.document(getIdByCode(code: ownCode))
+            .updateData(["partner_code": " "])
+        } catch {
+            print("cannot get document by code")
         }
-        completion("연동이 해지되었습니다.")
     }
 }
-
-enum ConnectionManagerResultType: Error {
-    case success
-    case callMySelf // 자신의 코드를 불러오는 경우
-    case invalidPartnerCode // 일치하는 파트너 코드가 없는 경우
-}
-
-

--- a/POMPOM/POMPOM/Networking/ConnectionManager.swift
+++ b/POMPOM/POMPOM/Networking/ConnectionManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import FirebaseFirestore
 
-struct ConnectionManager {
+struct CodeManager {
     let usersRef = Firestore.firestore().collection("users")
     
     func isExistingCode(code: String) async -> Bool {

--- a/POMPOM/POMPOM/UI/ChatView/MessageListView.swift
+++ b/POMPOM/POMPOM/UI/ChatView/MessageListView.swift
@@ -26,7 +26,7 @@ struct MessageListView: View {
                                           recievedBubble: message.messageTo == myCode ? true : false,
                                           commentedTime: message.timestamp)
                             .task {
-                                self.myCode = CodeManager().getCode()
+                                self.myCode = ConnectionManager().getCode()
                             }
                         
                     }

--- a/POMPOM/POMPOM/UI/ChatView/TextFieldView.swift
+++ b/POMPOM/POMPOM/UI/ChatView/TextFieldView.swift
@@ -34,8 +34,8 @@ struct TextFieldView: View {
     }
     
     func sendMessage() async {
-        let myCode =  CodeManager().getCode()
-        let partnerCode = CodeManager().getPartnerCode()
+        let myCode =  ConnectionManager().getCode()
+        let partnerCode = ConnectionManager().getPartnerCode()
         
         reference.addDocument(data: [
             "id": Int(Date().timeIntervalSince1970*1000),

--- a/POMPOM/POMPOM/UI/ClothPickerView/ViewModel/PickerViewModel.swift
+++ b/POMPOM/POMPOM/UI/ClothPickerView/ViewModel/PickerViewModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import SystemConfiguration
 import Combine
 
-class PickerViewModel: ClothViewModel {
+class PickerViewModel: ClothesViewModel {
     //MARK: - Propeties
     @Published var currentType: ClothCategory = .hat
     //UI 에 보여지는 컬러, 옷
@@ -105,7 +105,7 @@ class PickerViewModel: ClothViewModel {
     func uploadItem() -> Future<Bool, Never> {
         return Future<Bool, Never> { promise in
             if let defaultCode: String = UserDefaults.standard.string(forKey: "code") {
-                self.networkManager.saveClothes(userCode: defaultCode, clothes: self.selectedItems) { result in
+                self.networkManager.setClothes(userCode: defaultCode, clothes: self.selectedItems) { result in
                     switch result {
                     case .success:
                         promise(.success(true))

--- a/POMPOM/POMPOM/UI/ClothPickerView/ViewModel/PickerViewModel.swift
+++ b/POMPOM/POMPOM/UI/ClothPickerView/ViewModel/PickerViewModel.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import SystemConfiguration
+import Combine
 
 class PickerViewModel: ClothViewModel {
     //MARK: - Propeties
@@ -101,11 +102,20 @@ class PickerViewModel: ClothViewModel {
         }
     }
     
-    func uploadItem() {
-        if let defaultCode: String = UserDefaults.standard.string(forKey: "code") {
-            networkManager.saveClothes(userCode: defaultCode, clothes: selectedItems)
-        } else {
-            print("DEBUG: 사용자 코드 조회 실패")
+    func uploadItem() -> Future<Bool, Never> {
+        return Future<Bool, Never> { promise in
+            if let defaultCode: String = UserDefaults.standard.string(forKey: "code") {
+                self.networkManager.saveClothes(userCode: defaultCode, clothes: self.selectedItems) { result in
+                    switch result {
+                    case .success:
+                        promise(.success(true))
+                    case .failure(let error):
+                        promise(.success(false))
+                    }
+                }
+            } else {
+                promise(.success(false))
+            }
         }
     }
 }

--- a/POMPOM/POMPOM/UI/CoupleView/CodeInputView.swift
+++ b/POMPOM/POMPOM/UI/CoupleView/CodeInputView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CodeInputView: View {
     @Binding var textInput: String
     var delegate: NetworkDelegate?
-    private let codeManager: CodeManager = CodeManager()
+    private let codeManager: ConnectionManager = ConnectionManager()
     let afterAction: () -> ()
     
     var body: some View {

--- a/POMPOM/POMPOM/UI/CoupleView/CodeOutputView.swift
+++ b/POMPOM/POMPOM/UI/CoupleView/CodeOutputView.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct CodeOutputView: View {
-    let code: String = CodeManager().getCode()
+    let code: String = ConnectionManager().getCode()
     let afterCopy: () -> ()
     private let pasteboard = UIPasteboard.general
-    private let codeViewModel: CodeManager = CodeManager()
+    private let codeViewModel: ConnectionManager = ConnectionManager()
     
     var body: some View {
         CodeView(title: "초대코드 확인", content: {

--- a/POMPOM/POMPOM/UI/CoupleView/CoupleView.swift
+++ b/POMPOM/POMPOM/UI/CoupleView/CoupleView.swift
@@ -6,12 +6,16 @@
 //
 
 import SwiftUI
+import Combine
 
 enum CharacterSize {
     case large, medium, small
 }
+var subscriptions: [AnyCancellable] = []
 
 struct CoupleView: View {
+    
+    
     @AppStorage("_isFirstLaunching") var isFirstLaunching: Bool = true
     @AppStorage("isConnectedPartner") var isConnectedPartnerStorage: Bool = false
 
@@ -200,12 +204,12 @@ struct CoupleView: View {
                     } else {
                         Button("완료") {
                             myClothViewModel.uploadItem()
+                                .sink { isSuccess in
+                                    showCustomAlert(with: isSuccess ? "업로드에 성공하였습니다" : "업로드에 실패하였습니다")
+                                }
+                                .store(in: &subscriptions)
                             sheetMode = .none
-                            
-                            Task {
-                                await myClothViewModel.requestClothes()
-
-                            }
+ 
                         }
                     }
                 }
@@ -251,8 +255,15 @@ struct CoupleView: View {
             OnboardingView(isFirstLunching: $isFirstLaunching)
         }
         .addCustomAlert(with: alertMessage, presenting: $showAlert)
-        
     }
+    
+    //MARK: - Helpers
+    func showCustomAlert(with message: String) {
+        alertMessage = message
+        showAlert = true
+    }
+    
+    
 }
 
 extension CoupleView: NetworkDelegate {

--- a/POMPOM/POMPOM/UI/CoupleView/CoupleView.swift
+++ b/POMPOM/POMPOM/UI/CoupleView/CoupleView.swift
@@ -56,7 +56,7 @@ struct CoupleView: View {
     
     @StateObject var myClothViewModel = PickerViewModel()
     @StateObject var partnerClothViewModel = ClothesViewModel()
-    var codeViewModel = CodeManager()
+    var codeViewModel = ConnectionManager()
     @State private var actionSheetPresented = false
     @State private var codeInput = ""
     @State private var commentInput = ""

--- a/POMPOM/POMPOM/UI/CoupleView/ViewModel/ClothesViewModel.swift
+++ b/POMPOM/POMPOM/UI/CoupleView/ViewModel/ClothesViewModel.swift
@@ -8,33 +8,49 @@
 import Foundation
 import SwiftUI
 
-class ClothViewModel: ObservableObject {
+enum ClothError: Error {
+    case noUserCode
+    case networking
+}
+
+class ClothesViewModel: ObservableObject {
     //MARK: - Propeties
     @Published var selectedItems: [ClothCategory : Cloth] = [:]
     
     var networkManager: ClothesManager = ClothesManager()
     
-    //CouplleView
-    
-    func requestClothes() async {
+    func requestMyClothes(completion: @escaping (Error?) -> Void) {
         if let defaultCode: String = UserDefaults.standard.string(forKey: "code") {
-            networkManager.loadClothes(userCode: defaultCode) { clothes in
-                withAnimation {
-                    self.selectedItems = clothes
+            print("DEBUG: requestMyClothes - userCode \(defaultCode) ")
+            networkManager.fetchClohtes(userCode: defaultCode) { result in
+                switch result {
+                case .success(let loadedItem):
+                    self.selectedItems = loadedItem
+                    print("DEBUG: requestMyClothes - response \(loadedItem) ")
+                    completion(nil)
+                case .failure(let error):
+                    completion(error)
                 }
             }
         } else {
-            print("DEBUG: 사용자 코드 조회 실패")
+            completion(ClothError.noUserCode)
         }
     }
     
-    func requestPartnerClothes() async {
+    //옷 불러오는 리스너 -> completion 핸들러 필요.
+    func addPartnerClothesListenr(completion: @escaping (Error?) -> Void)  {
         if let defaultCode: String = UserDefaults.standard.string(forKey: "partner_code") {
-            networkManager.loadClothes(userCode: defaultCode) { clothes in
-                    self.selectedItems = clothes
+            networkManager.addClothesListner(userCode: defaultCode) { result in
+                switch result {
+                case .success(let loadedItem):
+                    self.selectedItems = loadedItem
+                    completion(nil)
+                case .failure(let error):
+                    completion(error)
+                }
             }
         } else {
-            print("DEBUG: 사용자 코드 조회 실패")
+            completion(ClothError.noUserCode)
         }
     }
     

--- a/POMPOM/POMPOM/UI/Onboarding/OnboardingView.swift
+++ b/POMPOM/POMPOM/UI/Onboarding/OnboardingView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct OnboardingView: View {
     
     @Binding var isFirstLunching: Bool
-    let codeManger = CodeManager()
+    let codeManger = ConnectionManager()
     
     let onboardingViewData : [OnboardingViewModel] = [
         OnboardingViewModel(

--- a/POMPOM/POMPOM/UI/SettingsView/SettingsView.swift
+++ b/POMPOM/POMPOM/UI/SettingsView/SettingsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(\.presentationMode) var presentationMode
-    private let codeManager: CodeManager = CodeManager()
+    private let codeManager: ConnectionManager = ConnectionManager()
     @State private var actionSheetPresented = false
     @State private var codeInput = ""
     @Binding var showAlert: Bool

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@
 - 실시간 채팅 : 옷을 맞춰보는 과정에서 채팅앱으로 이동하지 않고 바로 소통
 
 
-##  Design
+## Design
 
 
 
 
-## :fireworks: Screenshots
+## Screenshots
 
-## :sparkles: Skills & Tech Stack
+## Skills & Tech Stack
 1. 이슈관리 : Notion
 2. 형상관리 : Github
 3. 커뮤니케이션 : Ryver, Notion
@@ -30,14 +30,14 @@
 - IDE : Xcode 13.4.1
 5. 상세사용
 - Application : SwiftUI
-- Design : Sketch, AfterEffect, Illustrator<br>
+- Design : Sketch, Illustrator<br>
 6. 라이브러리
 ```swift
 import SwiftUI
 import Combine
 import FirebaseFirestore
 ```
-## 🔀 Git
+## Git
 
 1. Commit 컨벤션
     - `ADD` : 새로운 기능 추가

--- a/README.md
+++ b/README.md
@@ -1,4 +1,58 @@
-# MC2-Team4-POMPOM
-OO아 내일 뭐 입고 와?
 
-https://www.notion.so/3f77e06336014d49927acc7fc10a7279
+![Let's POMPOM](https://user-images.githubusercontent.com/89325126/174469713-8a624147-0a14-4337-b043-490874e69363.jpeg)
+
+
+# POMPOM
+
+폼폼은 커플들이 데이트 전날 서로의 옷을 직접 보지않고 맞춰볼 수 있는 실시간 시밀러룩 메이킹 앱입니다.
+
+## Features
+
+- 착장 등록 : 직관적인 UI로 자신이 내일 입고갈 옷의 컬러감, 모양을 빠르고 쉽게 선택
+- 파트너 연결 : 로그인 없이 코드 복사만으로 상대방과 연결
+- 실시간 연동 : 상대방이 옷을 수정하면 실시간으로 상대방에게 자신의 착장을 공유
+- 실시간 채팅 : 옷을 맞춰보는 과정에서 채팅앱으로 이동하지 않고 바로 소통
+
+
+##  Design
+
+
+
+
+## :fireworks: Screenshots
+
+## :sparkles: Skills & Tech Stack
+1. 이슈관리 : Notion
+2. 형상관리 : Github
+3. 커뮤니케이션 : Ryver, Notion
+4. 개발환경
+- OS : MacOS(M1Pro)
+- IDE : Xcode 13.4.1
+5. 상세사용
+- Application : SwiftUI
+- Design : Sketch, AfterEffect, Illustrator<br>
+6. 라이브러리
+```swift
+import SwiftUI
+import Combine
+import FirebaseFirestore
+```
+## 🔀 Git
+
+1. Commit 컨벤션
+    - `ADD` : 새로운 기능 추가
+    - `FIX` : 버그 수정
+    - `HOTFIX` : 긴급한 오류 수정
+    - `REFACTOR` : 코드 리팩토링 (기능 말고 성능 개선)
+    - `DELETE` : 기능 또는 파일 삭제
+    
+
+3. Git 브랜치
+    - `master` : 배포
+    - `develop` : 개발된 기능(feature)을 통합하는 브랜치
+    - `asset` : asset 을 수정, 추가, 삭제하는 브랜치
+
+## : Authors
+
+
+[Documentation](./Docs/)


### PR DESCRIPTION
## 작업내용
- 옷 업로드 네트워킹 로직을 Combine 을 사용해 리팩터링하였습니다,
- CodeManager 와 ConnectionManager 이 담고있는 메서드들의 기능이 클래스의 이름과 맞지않아 둘의 이름을 치환했습니다.
- 리스너를 붙여서 자신의 착장을 불러오던 메서드를 한번만 옷을 불러오는 메서드인 fetchClothes를 따로 만들어 대체하였습니다.

## 고민사항
- `CodeManager`, `ConnectionManager` 간의 상호의존성이 심해, 클래스간 독립성이 떨어져 가독성이 좋지 않은 것 같다.
    
    → 둘을 완전히 분리하고 동기처리가 필요한 부분읜  ViewModel 에서 동기처리를 해주면 될 것 같다.
    
    즉 현재 위계관계도인
    
    ---
    
    - `ClothesViewModel`
        - `ClothManager`
            - `ConnectionManager`
                - `CodeManager`
    
    를
    
    ---
    
    - `ClothesViewModel` ( = `ClothManager` 와 병합)
        - `ConnectionManager`
        - `CodeManager`
    
    와 같이 수정해서
    특정 Manager 는 해당하는 카테고리의 네트워킹 로직만을 담고있도록 하고자한다.

## 특이사항
- 제가 작성한 코드가 아니라서 리팩터링에 조금 어려움을 겪고 있습니다. 팀원들과 커뮤니케이션 해가면서 전체 프로젝트의 코드를 맞춰갈 예정입니다.

## 사진