### PR TITLE
[ADD]: CodeService, CodeManagerTest 추가

### DIFF
--- a/POMPOM/POMPOM.xcodeproj/project.pbxproj
+++ b/POMPOM/POMPOM.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		AB5DDF072876953B00C906E0 /* CoupleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5DDF062876953B00C906E0 /* CoupleViewModel.swift */; };
 		AB5DDF092876FD4800C906E0 /* CoupleView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5DDF082876FD4800C906E0 /* CoupleView+Extensions.swift */; };
 		AB73291C288D131A00D50C13 /* CodeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB73291B288D131A00D50C13 /* CodeService.swift */; };
+		AB73291F288D1C2600D50C13 /* CodeManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB73291E288D1C2600D50C13 /* CodeManagerTest.swift */; };
 		ABC4C5192859A6FB00D064E4 /* SheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC4C5182859A6FB00D064E4 /* SheetView.swift */; };
 		ABFEE2122855A86D007817D3 /* CodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABFEE2112855A86D007817D3 /* CodeView.swift */; };
 		ABFEE2142855F2C1007817D3 /* CommentTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABFEE2132855F2C1007817D3 /* CommentTextField.swift */; };
@@ -73,6 +74,7 @@
 		AB5DDF062876953B00C906E0 /* CoupleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoupleViewModel.swift; sourceTree = "<group>"; };
 		AB5DDF082876FD4800C906E0 /* CoupleView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoupleView+Extensions.swift"; sourceTree = "<group>"; };
 		AB73291B288D131A00D50C13 /* CodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeService.swift; sourceTree = "<group>"; };
+		AB73291E288D1C2600D50C13 /* CodeManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeManagerTest.swift; sourceTree = "<group>"; };
 		ABC4C5182859A6FB00D064E4 /* SheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetView.swift; sourceTree = "<group>"; };
 		ABFEE2112855A86D007817D3 /* CodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeView.swift; sourceTree = "<group>"; };
 		ABFEE2132855F2C1007817D3 /* CommentTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentTextField.swift; sourceTree = "<group>"; };
@@ -225,6 +227,7 @@
 				C06CE15F2851DD6700BBDA68 /* NotificationManager.swift */,
 				2521EC75285A0D2400B02E1A /* ClothesManager.swift */,
 				AB73291B288D131A00D50C13 /* CodeService.swift */,
+				AB73291E288D1C2600D50C13 /* CodeManagerTest.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -515,6 +518,7 @@
 				AE8509F52859C0EF00D11812 /* SlideModalView.swift in Sources */,
 				C06CE1632851DD8500BBDA68 /* LoginView.swift in Sources */,
 				C0A779D32849E1C60086810C /* Model.xcdatamodeld in Sources */,
+				AB73291F288D1C2600D50C13 /* CodeManagerTest.swift in Sources */,
 				C0182C4028598470000F0A6A /* Seperator.swift in Sources */,
 				D40F41842857135D0037B3EB /* OnboardingViewModel.swift in Sources */,
 				D430FCFE2859A76900F216CB /* ColorPickerView.swift in Sources */,

--- a/POMPOM/POMPOM.xcodeproj/project.pbxproj
+++ b/POMPOM/POMPOM.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		AB132FED2854BF500023DBD0 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB132FEC2854BF500023DBD0 /* Constant.swift */; };
 		AB5DDF072876953B00C906E0 /* CoupleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5DDF062876953B00C906E0 /* CoupleViewModel.swift */; };
 		AB5DDF092876FD4800C906E0 /* CoupleView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5DDF082876FD4800C906E0 /* CoupleView+Extensions.swift */; };
+		AB73291C288D131A00D50C13 /* CodeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB73291B288D131A00D50C13 /* CodeService.swift */; };
 		ABC4C5192859A6FB00D064E4 /* SheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC4C5182859A6FB00D064E4 /* SheetView.swift */; };
 		ABFEE2122855A86D007817D3 /* CodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABFEE2112855A86D007817D3 /* CodeView.swift */; };
 		ABFEE2142855F2C1007817D3 /* CommentTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABFEE2132855F2C1007817D3 /* CommentTextField.swift */; };
@@ -71,6 +72,7 @@
 		AB132FEC2854BF500023DBD0 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		AB5DDF062876953B00C906E0 /* CoupleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoupleViewModel.swift; sourceTree = "<group>"; };
 		AB5DDF082876FD4800C906E0 /* CoupleView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoupleView+Extensions.swift"; sourceTree = "<group>"; };
+		AB73291B288D131A00D50C13 /* CodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeService.swift; sourceTree = "<group>"; };
 		ABC4C5182859A6FB00D064E4 /* SheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetView.swift; sourceTree = "<group>"; };
 		ABFEE2112855A86D007817D3 /* CodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeView.swift; sourceTree = "<group>"; };
 		ABFEE2132855F2C1007817D3 /* CommentTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentTextField.swift; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 				C06CE1582851DCD600BBDA68 /* CodeManager.swift */,
 				C06CE15F2851DD6700BBDA68 /* NotificationManager.swift */,
 				2521EC75285A0D2400B02E1A /* ClothesManager.swift */,
+				AB73291B288D131A00D50C13 /* CodeService.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -490,6 +493,7 @@
 				C0A779C72849E1C50086810C /* POMPOMApp.swift in Sources */,
 				C069E259287299A7000874BB /* ClothViewModel.swift in Sources */,
 				AE850A07285B238D00D11812 /* Message.swift in Sources */,
+				AB73291C288D131A00D50C13 /* CodeService.swift in Sources */,
 				C0C7EE9A285B42A2003DA1A9 /* CustomAlert.swift in Sources */,
 				D430FD42285B984200F216CB /* DayDisplayView.swift in Sources */,
 				C06CE1502851DC5C00BBDA68 /* CodeOutputView.swift in Sources */,

--- a/POMPOM/POMPOM/Networking/CodeManagerTest.swift
+++ b/POMPOM/POMPOM/Networking/CodeManagerTest.swift
@@ -1,0 +1,72 @@
+//
+//  CodeManagerTest.swift
+//  POMPOM
+//
+//  Created by 김남건 on 2022/07/24.
+//
+
+import Foundation
+import SwiftUI
+
+struct CodeManagerTest {
+    @AppStorage("code") var code: String?
+    @AppStorage("partner_code") var partnerCode: String?
+    
+    func generateRandomCode() -> String {
+        let elements = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        return String((0..<10).map { _ in elements.randomElement()! })
+    }
+    
+    func assignNewCode() async throws -> String {
+        var newCode = ""
+        
+        repeat {
+            newCode = generateRandomCode()
+        } while try await CodeService.shared.isExistingCode(code: newCode)
+        
+        UserDefaults.standard.set(newCode, forKey: "code")
+        return newCode
+    }
+    
+    mutating func connectWithPartner(partnerCode: String) async throws {
+        guard let code = code else {
+            throw CodeServiceError.myCodeNotExists
+        }
+        
+        guard partnerCode != code else {
+            throw CodeServiceError.connectToMySelf
+        }
+        
+        guard try await CodeService.shared.isExistingCode(code: partnerCode) else {
+            throw CodeServiceError.invalidPartnerCode
+        }
+        
+        async let isMyDocumentUpdated = try CodeService.shared.updatePartnerCode(myCode: code, partnerCode: partnerCode)
+        
+        async let isPartnerDocumentUpdated = try CodeService.shared.updatePartnerCode(myCode: partnerCode, partnerCode: code)
+        
+        let _ = (try await isMyDocumentUpdated, try await isPartnerDocumentUpdated)
+        
+        self.partnerCode = partnerCode
+    }
+    
+    func deletePartnerCode() async throws {
+        guard let code = code else {
+            return
+        }
+        
+        guard let partnerCode = partnerCode else {
+            return
+        }
+        
+        async let isMyDocumentUpdated = try CodeService.shared.deletePartnerCode(in: code)
+        async let isPartnerDocumentUpdated = try CodeService.shared.deletePartnerCode(in: partnerCode)
+        
+        let _ = (try await isMyDocumentUpdated, try await isPartnerDocumentUpdated)
+        self.partnerCode = nil
+    }
+}
+
+enum CodeServiceError: Error {
+    case myCodeNotExists, connectToMySelf, invalidPartnerCode
+}

--- a/POMPOM/POMPOM/Networking/CodeService.swift
+++ b/POMPOM/POMPOM/Networking/CodeService.swift
@@ -1,0 +1,35 @@
+//
+//  CodeService.swift
+//  POMPOM
+//
+//  Created by 김남건 on 2022/07/24.
+//
+
+import Foundation
+import FirebaseFirestore
+
+struct CodeService {
+    let usersCollection = Firestore.firestore().collection("users")
+    
+    func isExistingCode(code: String) async throws -> Bool {
+        let document = usersCollection.document(code)
+        
+        return try await document.getDocument().exists
+    }
+    
+    func saveCode(code: String) async throws {
+        try await usersCollection.document(code).setData([:])
+    }
+    
+    func updatePartnerCode(myCode: String, partnerCode: String) async throws {
+        try await usersCollection.document(myCode).updateData([
+            "partner_code": partnerCode
+        ])
+    }
+    
+    func deletePartnerCode(myCode: String) async throws {
+        try await usersCollection.document(myCode).updateData([
+            "partner_code" : FieldValue.delete()
+        ])
+    }
+}

--- a/POMPOM/POMPOM/Networking/CodeService.swift
+++ b/POMPOM/POMPOM/Networking/CodeService.swift
@@ -9,6 +9,10 @@ import Foundation
 import FirebaseFirestore
 
 struct CodeService {
+    static let shared = CodeService()
+    
+    private init() {}
+    
     let usersCollection = Firestore.firestore().collection("users")
     
     func isExistingCode(code: String) async throws -> Bool {
@@ -21,15 +25,19 @@ struct CodeService {
         try await usersCollection.document(code).setData([:])
     }
     
-    func updatePartnerCode(myCode: String, partnerCode: String) async throws {
+    func updatePartnerCode(myCode: String, partnerCode: String) async throws -> Bool {
         try await usersCollection.document(myCode).updateData([
             "partner_code": partnerCode
         ])
+        
+        return true // async let 사용 위해 dummy return 값 부여
     }
     
-    func deletePartnerCode(myCode: String) async throws {
+    func deletePartnerCode(in myCode: String) async throws -> Bool {
         try await usersCollection.document(myCode).updateData([
             "partner_code" : FieldValue.delete()
         ])
+        
+        return true // async let 사용 위해 dummy return 값 부여
     }
 }


### PR DESCRIPTION
## 작업내용
* CodeService: ConnectionManager 대체, Firebase에서의 CRUD 위한 메서드 구현, 싱글턴 패턴 사용
* CodeManagerTest: CodeManager 대체, CodeService 사용하여 Firebase에서의 code CRUD 작업 후, UserDefaults에 반영
